### PR TITLE
Update max31865.c

### DIFF
--- a/max31865.c
+++ b/max31865.c
@@ -105,11 +105,11 @@ void max31865_init(max31865_t*  device,
 
     // low and high fault threshold setup
     temp_1 = device->highFaultThreshold;
-    buff[0] = (uint8_t)(temp_1);
-    buff[1] = (uint8_t)(temp_1 >> 8);
+    buff[0] = (uint8_t)(temp_1 >> 8);
+    buff[1] = (uint8_t)(temp_1);
     temp_1 = device->lowFaultThreshold;
-    buff[2] = (uint8_t)(temp_1);
-    buff[3] = (uint8_t)(temp_1 >> 8);
+    buff[2] = (uint8_t)(temp_1 >> 8);
+    buff[3] = (uint8_t)(temp_1);
 
     temp = device->configReg;
     _write_n_reg(device, REG_WRITE_CONFIGURATION, &temp, 1);
@@ -142,7 +142,7 @@ uint16_t max31865_readADC(const max31865_t* device)
     }
 
 
-    return (((uint16_t)((buff[0]<<8) | buff[1])) >> 1);
+    return ((uint16_t)((buff[0]<<8) | (buff[1] >> 1)) );
 }
 
 float max31865_readRTD_ohm(const max31865_t* device)


### PR DESCRIPTION
The threshold register value was not been written correctly. The most significant bits come first at buff[0] with a proper bit rotation to the right then the lest significant bits.
In the reading ADC register value, all of the 16-bits value was been rotated to the right instead of the low significat half(buff[1]).. With this changes the trheshold callback is triggered when there is not sensor attached to the chip. And the readings are correct